### PR TITLE
Compatibility with Django 1.8

### DIFF
--- a/webmachine/wrappers.py
+++ b/webmachine/wrappers.py
@@ -164,6 +164,11 @@ class WMResponse(HttpResponse):
 
     server = header_getter('Server', '14.38')
 
+    def _convert_to_ascii(self, header, value):
+        def convert(s):
+            return s.decode('ascii')
+        return convert(header), convert(value)
+
     #
     # charset
     #

--- a/webmachine/wrappers.py
+++ b/webmachine/wrappers.py
@@ -80,7 +80,7 @@ class WMResponse(HttpResponse):
         self.request = request
         self._headerlist = []
 
-        HttpResponse.__init__(self, content=content, mimetype=mimetype, 
+        HttpResponse.__init__(self, content=content,
                 status=status_code, content_type=content_type)
 
         


### PR DESCRIPTION
- HttpResponse.mimetype is deprecated since Django 1.7
- added missing `_convert_to_ascii` method