### PR TITLE
Support for Access-Control-Max-Age: 1000 like headers

### DIFF
--- a/webmachine/wrappers.py
+++ b/webmachine/wrappers.py
@@ -166,7 +166,10 @@ class WMResponse(HttpResponse):
 
     def _convert_to_ascii(self, header, value):
         def convert(s):
-            return s.decode('ascii')
+            try:
+                return s.decode('ascii')
+            except AttributeError:
+                return s
         return convert(header), convert(value)
 
     #


### PR DESCRIPTION
It turns out the previous implementation was an assumption that every header would be a 'string'.

However, it turns out, some of our systems use `Access-Control-Max-Age: 1000` like headers. Since it was working in `0.2.1`, I decided not to change the client code and modify dj-webmachine behavior closer to the one we observed earlier: simply ignore `int` and `float` headers.