### PR TITLE
Compatibility with Django 1.8. Migrations

### DIFF
--- a/webmachine/migrations/0001_initial.py
+++ b/webmachine/migrations/0001_initial.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+from django.conf import settings
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        migrations.swappable_dependency(settings.AUTH_USER_MODEL),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='Consumer',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('name', models.CharField(max_length=255)),
+                ('key', models.CharField(max_length=32)),
+                ('secret', models.CharField(max_length=32)),
+                ('description', models.TextField()),
+                ('status', models.SmallIntegerField(default=1, choices=[(1, 'Pending'), (2, 'Accepted'), (3, 'Canceled'), (4, 'Rejected')])),
+                ('user', models.ForeignKey(related_name='consumers_user', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Nonce',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('token_key', models.CharField(max_length=32)),
+                ('consumer_key', models.CharField(max_length=32)),
+                ('key', models.CharField(max_length=255)),
+            ],
+        ),
+        migrations.CreateModel(
+            name='Token',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('key', models.CharField(max_length=32)),
+                ('secret', models.CharField(max_length=32)),
+                ('token_type', models.SmallIntegerField(choices=[(1, 'Access'), (2, 'Request')])),
+                ('callback', models.CharField(max_length=2048)),
+                ('callback_confirmed', models.BooleanField(default=False)),
+                ('verifier', models.CharField(max_length=16)),
+                ('timestamp', models.IntegerField(default=1454054828.411826)),
+                ('is_approved', models.BooleanField(default=False)),
+                ('consumer', models.ForeignKey(related_name='tokens_consumer', to='webmachine.Consumer')),
+                ('user', models.ForeignKey(related_name='tokens_user', blank=True, to=settings.AUTH_USER_MODEL, null=True)),
+            ],
+        ),
+    ]

--- a/webmachine/migrations/0002_auto_20160129_0014.py
+++ b/webmachine/migrations/0002_auto_20160129_0014.py
@@ -1,0 +1,19 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import models, migrations
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('webmachine', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.AlterField(
+            model_name='token',
+            name='timestamp',
+            field=models.IntegerField(default=1454055261.499175),
+        ),
+    ]

--- a/webmachine/migrations/0002_auto_20160129_0247.py
+++ b/webmachine/migrations/0002_auto_20160129_0247.py
@@ -2,6 +2,7 @@
 from __future__ import unicode_literals
 
 from django.db import models, migrations
+import webmachine.models
 
 
 class Migration(migrations.Migration):
@@ -14,6 +15,6 @@ class Migration(migrations.Migration):
         migrations.AlterField(
             model_name='token',
             name='timestamp',
-            field=models.IntegerField(default=1454055261.499175),
+            field=models.IntegerField(default=webmachine.models.generate_time),
         ),
     ]

--- a/webmachine/models.py
+++ b/webmachine/models.py
@@ -15,6 +15,11 @@ TOKEN_TYPES, PENDING, CONSUMER_STATES
 
 from webmachine.managers import ConsumerManager, TokenManager
 
+
+def generate_time():
+    return time.time()
+
+
 def generate_random(length=SECRET_SIZE):
     return User.objects.make_random_password(length=length)
 
@@ -41,6 +46,7 @@ class Consumer(models.Model):
 
         return urllib.urlencode(data)
 
+
 class Token(models.Model):
     key = models.CharField(max_length=KEY_SIZE)
     secret = models.CharField(max_length=SECRET_SIZE)
@@ -50,7 +56,7 @@ class Token(models.Model):
     verifier = models.CharField(max_length=VERIFIER_SIZE)
     consumer = models.ForeignKey(Consumer,
             related_name="tokens_consumer")
-    timestamp = models.IntegerField(default=time.time())
+    timestamp = models.IntegerField(default=generate_time)
     user = models.ForeignKey(User, null=True, blank=True, 
             related_name="tokens_user")
     is_approved = models.BooleanField(default=False)


### PR DESCRIPTION
`python manage.py migrate` fails on migrating webmachine application. Output:

```
  File "/usr/local/lib/python2.7/dist-packages/django/db/backends/utils.py", line 79, in execute
    return super(CursorDebugWrapper, self).execute(sql, params)
  File "/usr/local/lib/python2.7/dist-packages/django/db/backends/utils.py", line 64, in execute
    return self.cursor.execute(sql, params)
  File "/usr/local/lib/python2.7/dist-packages/django/db/utils.py", line 97, in __exit__
    six.reraise(dj_exc_type, dj_exc_value, traceback)
  File "/usr/local/lib/python2.7/dist-packages/django/db/backends/utils.py", line 62, in execute
    return self.cursor.execute(sql)
django.db.utils.ProgrammingError: relation "auth_user" does not exist
```
